### PR TITLE
ci(renovate): remove minimumReleaseAgeNpm

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,6 @@
     "group:jsUnitTest",
     "group:vite",
     "helpers:pinGitHubActionDigestsToSemver",
-    "security:minimumReleaseAgeNpm",
     "security:openssf-scorecard",
     ":approveMajorUpdates",
     ":automergeAll",


### PR DESCRIPTION
* the preset is already included in best practices